### PR TITLE
Deprecate Logger.warn

### DIFF
--- a/lib/salesforce.ex
+++ b/lib/salesforce.ex
@@ -59,7 +59,7 @@ defmodule Salesforce do
           })
         else
           error ->
-            Logger.warn(
+            Logger.warning(
               "Failed to authenticate for app_token #{app.app_token} with salesforce: #{inspect(error)}"
             )
 
@@ -190,7 +190,7 @@ defmodule Salesforce do
       end
     else
       {:error, reason} ->
-        Logger.warn(
+        Logger.warning(
           "Failed to authenticate for app_token #{app_token} with salesforce: #{inspect(reason)}"
         )
 
@@ -223,7 +223,7 @@ defmodule Salesforce do
       {:ok, %{client: client, refresh_token: refresh_token, access_token: access_token}}
     else
       {:error, reason} ->
-        Logger.warn(
+        Logger.warning(
           "Failed to refresh for app_token #{app_token} with salesforce: #{inspect(reason)}"
         )
 

--- a/lib/salesforce.ex
+++ b/lib/salesforce.ex
@@ -138,7 +138,7 @@ defmodule Salesforce do
   # Authentication Response Example:
   # {:ok,
   # %ExForce.OAuthResponse{
-  #   access_token: "00DDp0000018Wr2!AQEAQDV4NO.YPKFZSFV38KxZAnDxVZX6wWV67isrYI124_3tbvJsFAnZwuS05hY0ElkIl_0rSvOBM2dc454I9DkPwPm7COBp",
+  #   access_token: "TOKEN",
   #   id: "https://login.salesforce.com/id/00DDp0000018Wr2MAE/005Dp000002NCZXIA4",
   #   instance_url: "https://userpilot-dev-ed.develop.my.salesforce.com",
   #   issued_at: ~U[2023-11-07 13:19:11.832Z],

--- a/lib/salesforce_kb.ex
+++ b/lib/salesforce_kb.ex
@@ -59,7 +59,7 @@ defmodule SalesforceKB do
           })
         else
           error ->
-            Logger.warn(
+            Logger.warning(
               "Failed to authenticate for app_token #{app.app_token} with salesforce: #{inspect(error)}"
             )
 
@@ -190,7 +190,7 @@ defmodule SalesforceKB do
        }}
     else
       {:error, reason} ->
-        Logger.warn(
+        Logger.warning(
           "Failed to authenticate for app_token #{app_token} with salesforce: #{inspect(reason)}"
         )
 
@@ -221,7 +221,7 @@ defmodule SalesforceKB do
       {:ok, %{client: client, refresh_token: refresh_token, access_token: access_token}}
     else
       {:error, reason} ->
-        Logger.warn(
+        Logger.warning(
           "Failed to refresh for app_token #{app_token} with salesforce: #{inspect(reason)}"
         )
 


### PR DESCRIPTION
Deprecate the usage of Logger.warn to avoid spamming logs with:

```

warning: the log level :warn is deprecated, use :warning instead
  (logger 1.16.3) lib/logger.ex:1168: Logger.elixir_level_to_erlang_level/1
  (logger 1.16.3) lib/logger.ex:627: Logger.compare_levels/2
  (logger_papertrail_backend 1.1.0) lib/logger_papertrail_backend/logger.ex:60: LoggerPapertrailBackend.Logger.meet_level?/2
  (logger_papertrail_backend 1.1.0) lib/logger_papertrail_backend/logger.ex:33: LoggerPapertrailBackend.Logger.handle_event/2
  (stdlib 5.2.3.5) gen_event.erl:814: :gen_event.server_update/4
  (stdlib 5.2.3.5) gen_event.erl:796: :gen_event.server_notify/4

```