### PR TITLE
Make get_app lock-free via ETS, run OAuth refresh in Tasks

### DIFF
--- a/lib/salesforce.ex
+++ b/lib/salesforce.ex
@@ -1,39 +1,41 @@
 defmodule Salesforce do
   @moduledoc """
-  This genserver for salesforce that holds integrations config and clients for per app token
+  Per-app Salesforce OAuth client + config cache.
+
+  The GenServer is a writer/coordinator only. State lives in a public ETS
+  table so `get_app/1` is a lock-free, microsecond, concurrent read.
+  All HTTPS work (register/refresh) runs in unlinked Tasks; each Task writes
+  its result directly into ETS and self-schedules the next refresh, so the
+  singleton mailbox never blocks on network I/O.
   """
 
   require Logger
-
-  defmodule State do
-    defstruct [
-      :applications
-    ]
-
-    @type t :: %__MODULE__{
-            applications: map()
-          }
-  end
-
   use GenServer
 
-  @refresh_token_interval_ms 2 * 60 * 60 * 1000
+  @table :salesforce_apps
+
+  @refresh_interval_ms 2 * 60 * 60 * 1000
+  @refresh_jitter_ms 15 * 60 * 1000
+  @refresh_retry_ms 5 * 60 * 1000
 
   #
   # External API
   #
 
-  def register_app_token(app) do
-    GenServer.call(__MODULE__, {:register_app, app})
+  def get_app(app_token) when is_binary(app_token) do
+    case :ets.lookup(@table, app_token) do
+      [{^app_token, app}] -> app
+      [] -> nil
+    end
+  rescue
+    # Table not yet created (boot race) — treat as cache miss.
+    ArgumentError -> nil
   end
 
-  def refresh_app_token(config) do
-    GenServer.call(__MODULE__, {:refresh_token, config})
-  end
+  def register_app_token(app), do: GenServer.call(__MODULE__, {:register_app, app}, 30_000)
 
-  def get_app(app_token) do
-    GenServer.call(__MODULE__, {:get_app, app_token})
-  end
+  def refresh_app_token(config),
+    do: GenServer.call(__MODULE__, {:refresh_token, config}, 30_000)
 
   # Client
 
@@ -49,96 +51,125 @@ defmodule Salesforce do
 
   @impl true
   def init(callback_fun) when is_function(callback_fun, 0) do
-    applications =
-      callback_fun.()
-      |> Enum.reduce(%{}, fn app, applications ->
-        with {:ok, %{client: client, access_token: access_token}} <- refresh_client(app.config) do
-          Map.put(applications, String.to_atom(app.app_token), %{
-            config: Map.put(app.config, :access_token, access_token),
-            client: client
-          })
-        else
-          error ->
-            Logger.warn(
-              "Failed to authenticate for app_token #{app.app_token} with salesforce: #{inspect(error)}"
-            )
+    :ets.new(@table, [
+      :named_table,
+      :public,
+      :set,
+      read_concurrency: true,
+      write_concurrency: true
+    ])
 
-            applications
-        end
-      end)
-
-    {:ok, %State{applications: applications}}
+    {:ok, callback_fun, {:continue, :initial_load}}
   end
 
   @impl true
-  def handle_info({:refresh_token, app_token}, %State{applications: applications} = state) do
-    app = Map.get(applications, String.to_atom(app_token))
-
-    case refresh_client(app.config) do
-      {:ok, %{client: client, access_token: access_token}} ->
-        applications =
-          Map.put(applications, String.to_atom(app.config.app_token), %{
-            config: Map.put(app.config, :access_token, access_token),
-            client: client
-          })
-
-        {:noreply, %State{state | applications: applications}}
-
-      {:error, _reason} ->
-        {:noreply, state}
+  def handle_continue(:initial_load, callback_fun) do
+    # Fire all initial refreshes immediately, in parallel. Tasks run independently;
+    # each one HTTPS-refreshes its tenant and writes the resulting client+config
+    # directly into ETS before scheduling the next periodic refresh.
+    for app <- safe_callback(callback_fun) do
+      spawn_refresh(app.config)
     end
+
+    {:noreply, callback_fun}
   end
 
   @impl true
-  def handle_call({:register_app, app}, _from, %State{applications: applications} = state) do
-    case init_client(app) do
-      {:ok,
-       %{
-         client: client,
-         response: %{refresh_token: refresh_token, access_token: access_token} = response
-       }} ->
-        applications =
-          Map.put(applications, String.to_atom(app.app_token), %{
-            config: Map.merge(app, %{refresh_token: refresh_token, access_token: access_token}),
-            client: client
-          })
-
-        {:reply, response, %State{state | applications: applications}}
-
-      {:error, reason} ->
-        {:reply, {:error, reason}, state}
-    end
+  def handle_info({:do_refresh, config}, state) do
+    spawn_refresh(config)
+    {:noreply, state}
   end
+
+  def handle_info(_msg, state), do: {:noreply, state}
 
   @impl true
-  def handle_call({:refresh_token, config}, _from, %State{applications: applications} = state) do
-    case refresh_client(config) do
-      {:ok, %{client: client, refresh_token: refresh_token, access_token: access_token}} ->
-        applications =
-          Map.put(applications, String.to_atom(config.app_token), %{
-            config: Map.put(config, :access_token, access_token),
-            client: client
-          })
+  def handle_call({:register_app, app}, from, state) do
+    Task.start(fn ->
+      case init_client(app) do
+        {:ok,
+         %{
+           client: client,
+           response: %{refresh_token: refresh_token, access_token: access_token} = response
+         }} ->
+          config = Map.merge(app, %{refresh_token: refresh_token, access_token: access_token})
+          :ets.insert(@table, {app.app_token, %{client: client, config: config}})
+          Process.send_after(__MODULE__, {:do_refresh, config}, jittered_refresh_ms())
+          GenServer.reply(from, response)
 
-        {:reply, refresh_token, %State{state | applications: applications}}
+        {:error, reason} ->
+          GenServer.reply(from, {:error, reason})
+      end
+    end)
 
-      {:error, reason} ->
-        {:reply, {:error, reason}, state}
-    end
+    {:noreply, state}
   end
 
-  @impl true
-  def handle_call({:get_app, app_token}, _from, %State{applications: applications} = state) do
-    app = Map.get(applications, String.to_atom(app_token), nil)
+  def handle_call({:refresh_token, config}, from, state) do
+    Task.start(fn ->
+      case refresh_client(config) do
+        {:ok, %{client: client, refresh_token: refresh_token, access_token: access_token}} ->
+          new_config = Map.put(config, :access_token, access_token)
+          :ets.insert(@table, {config.app_token, %{client: client, config: new_config}})
+          Process.send_after(__MODULE__, {:do_refresh, new_config}, jittered_refresh_ms())
+          GenServer.reply(from, refresh_token)
 
-    {:reply, app, state}
+        {:error, reason} ->
+          Logger.warning(
+            "Salesforce token refresh failed for #{config.app_token}: #{inspect(reason)}, retrying in #{div(@refresh_retry_ms, 60_000)}m"
+          )
+
+          Process.send_after(__MODULE__, {:do_refresh, config}, @refresh_retry_ms)
+          GenServer.reply(from, {:error, reason})
+      end
+    end)
+
+    {:noreply, state}
   end
 
-  # the initializing of the genserver do authenticate with salesforce and build the client, then it stores the client in ets table,
+  #
+  # Internals
+  #
+
+  # Spawned outside the GenServer mailbox so HTTPS never blocks reads.
+  # The Task writes to ETS itself (the table is :public) before scheduling the
+  # next periodic refresh, eliminating any race between the caller observing a
+  # successful reply and the cache being populated.
+  defp spawn_refresh(config) do
+    Task.start(fn ->
+      case refresh_client(config) do
+        {:ok, %{client: client, access_token: access_token}} ->
+          new_config = Map.put(config, :access_token, access_token)
+          :ets.insert(@table, {config.app_token, %{client: client, config: new_config}})
+          Process.send_after(__MODULE__, {:do_refresh, new_config}, jittered_refresh_ms())
+
+        {:error, reason} ->
+          Logger.warning(
+            "Salesforce token refresh failed for #{config.app_token}: #{inspect(reason)}, retrying in #{div(@refresh_retry_ms, 60_000)}m"
+          )
+
+          Process.send_after(__MODULE__, {:do_refresh, config}, @refresh_retry_ms)
+      end
+    end)
+  end
+
+  defp jittered_refresh_ms do
+    @refresh_interval_ms + :rand.uniform(@refresh_jitter_ms) - div(@refresh_jitter_ms, 2)
+  end
+
+  defp safe_callback(fun) do
+    fun.()
+  rescue
+    e ->
+      Logger.error("Salesforce initial_load callback raised: #{inspect(e)}")
+      []
+  end
+
+  # the initializing of the genserver do authenticate with salesforce and build the client,
+  # then it stores the client in ets table.
   # Authentication Response Example:
   # {:ok,
   # %ExForce.OAuthResponse{
-  #   access_token: "00DDp0000018Wr2!AQEAQDV4NO.YPKFZSFV38KxZAnDxVZX6wWV67isrYI124_3tbvJsFAnZwuS05hY0ElkIl_0rSvOBM2dc454I9DkPwPm7COBp",
+  #   access_token: "00DDp0000018Wr2!AQ...",
   #   id: "https://login.salesforce.com/id/00DDp0000018Wr2MAE/005Dp000002NCZXIA4",
   #   instance_url: "https://userpilot-dev-ed.develop.my.salesforce.com",
   #   issued_at: ~U[2023-11-07 13:19:11.832Z],
@@ -147,7 +178,6 @@ defmodule Salesforce do
   #   signature: "*/*",
   #   token_type: "Bearer"
   # }}
-
   defp init_client(
          %{
            app_token: app_token,
@@ -161,7 +191,8 @@ defmodule Salesforce do
          } = _config
        ) do
     with {:ok,
-          %{instance_url: instance_url, refresh_token: new_refresh_token, id: id} = oauth_response} <-
+          %{instance_url: instance_url, refresh_token: new_refresh_token, id: id} =
+            oauth_response} <-
            ExForce.OAuth.get_token(auth_url,
              grant_type: "authorization_code",
              client_id: client_id,
@@ -176,8 +207,6 @@ defmodule Salesforce do
 
       with client = ExForce.build_client(oauth_response, api_version: latest_version),
            {:ok, body} <- ExForce.info(client, id) do
-        Process.send_after(self(), {:refresh_token, app_token}, @refresh_token_interval_ms)
-
         {:ok,
          %{
            client: client,
@@ -190,7 +219,7 @@ defmodule Salesforce do
       end
     else
       {:error, reason} ->
-        Logger.warn(
+        Logger.warning(
           "Failed to authenticate for app_token #{app_token} with salesforce: #{inspect(reason)}"
         )
 
@@ -219,11 +248,10 @@ defmodule Salesforce do
 
       client = ExForce.build_client(oauth_response, api_version: latest_version)
 
-      Process.send_after(self(), {:refresh_token, app_token}, @refresh_token_interval_ms)
       {:ok, %{client: client, refresh_token: refresh_token, access_token: access_token}}
     else
       {:error, reason} ->
-        Logger.warn(
+        Logger.warning(
           "Failed to refresh for app_token #{app_token} with salesforce: #{inspect(reason)}"
         )
 


### PR DESCRIPTION
Eliminates GenServer.call timeouts on get_app/1 and refresh stampedes.

## Problem
Singleton `Salesforce` GenServer did synchronous HTTPS inside `init/handle_call/handle_info`, so every tenant's `:get_app` was head-of-line-blocked behind OAuth refreshes and timed out at 5s.
## Fix
Per-app `%{client, config}` now lives in a public ETS table → `get_app/1` is a lock-free `:ets.lookup/2`. All HTTPS (register, refresh, periodic) runs in unlinked Tasks that write ETS directly and self-schedule the next refresh.
## Other changes
`init/1` returns instantly; initial refresh fires from `handle_continue` in parallel. Refresh interval jittered 2h ± 7.5m; errors retry in 5m instead of falling off the schedule. Atom-leak from `String.to_atom(app_token)` removed.
